### PR TITLE
Added ability to re-select a modified region using the 'gv' and V-LINE support

### DIFF
--- a/lua/markdowny.lua
+++ b/lua/markdowny.lua
@@ -8,6 +8,17 @@ local function is_double_char(str, idx)
     return #char ~= display_width
 end
 
+--- This update the '>' mark, which represents the end column
+--- position of the selection, in visual mode after adding or
+--- removing a surround, enabling the region to be reselected
+--- using the 'gv' command.
+---
+--- @param line number The line number of the mark to update.
+--- @param col  number The column/row number of the mark to update.
+local function update_end_selection_mark(line, col)
+    vim.api.nvim_buf_set_mark(0, '>', line, col, {})
+end
+
 local function surrounder(pos_start, pos_end, before, after)
     local start_line = vim.api.nvim_buf_get_lines(0, pos_start[1] - 1, pos_start[1], true)[1]
 
@@ -35,6 +46,9 @@ local function surrounder(pos_start, pos_end, before, after)
         end
 
         vim.api.nvim_buf_set_lines(0, pos_start[1] - 1, pos_start[1], true, { start_line })
+
+        -- Added #after and #before because both surrounds are on the same line.
+        update_end_selection_mark(pos_end[1], pos_end[2] + #after + #before)
     else
         local end_line = vim.api.nvim_buf_get_lines(0, pos_end[1] - 1, pos_end[1], true)[1]
 
@@ -66,6 +80,9 @@ local function surrounder(pos_start, pos_end, before, after)
 
         vim.api.nvim_buf_set_lines(0, pos_start[1] - 1, pos_start[1], true, { start_line })
         vim.api.nvim_buf_set_lines(0, pos_end[1] - 1, pos_end[1], true, { end_line })
+
+        -- Added only #after because surrounds are on different lines.
+        update_end_selection_mark(pos_end[1], pos_end[2] + #after)
     end
 end
 local function make_surrounder_function(before, after)

--- a/lua/markdowny.lua
+++ b/lua/markdowny.lua
@@ -92,6 +92,13 @@ local function make_surrounder_function(before, after)
         -- {line, col}
         local pos_end = vim.api.nvim_buf_get_mark(0, '>')
 
+        -- Manually count chars of last selected line in V-LINE mode due
+        -- to '>' reaching max int value. Address if it's neovim bug.
+        if vim.fn.visualmode() == 'V' then
+            local last_line = vim.api.nvim_buf_get_lines(0, pos_end[1] - 1, pos_end[1], true)[1]
+            pos_end[2] = #last_line - 1
+        end
+
         surrounder(pos_start, pos_end, before, after)
     end
 end


### PR DESCRIPTION
This patch utilizes the `'>'` symbol to obtain the end column position of a selection. This capability enables the updating of positions in visual selections after adding or removing a surround, thus facilitating the reselection of the region using the `gv` command.


### Before

https://user-images.githubusercontent.com/24286590/213634087-0c777627-5e49-41e2-b76e-b66a099268dd.mp4

### After


https://user-images.githubusercontent.com/24286590/213634116-852dd159-1276-4254-a4b6-4b60451e4736.mp4



**[Update]**

The commit c141afd96ed66e751b94379ccb1a7941607800ae addresses an issue in the original code where the surround in the `V-LINE` selection was not correctly positioned. It also fixes an error that was introduced when using the `gv` command for re-selecting the surround that was added in `V-LINE`.
