### PR TITLE
Update selection while removing surrounds & support for 'V-LINE' and 'gv' in markdown links.

### DIFF
--- a/lua/markdowny.lua
+++ b/lua/markdowny.lua
@@ -111,14 +111,11 @@ M.bold = make_surrounder_function('**', '**')
 M.italic = make_surrounder_function('_', '_')
 
 function M.link()
-    local pos_start = vim.api.nvim_buf_get_mark(0, '<')
-    local pos_end = vim.api.nvim_buf_get_mark(0, '>')
-
     vim.ui.input({ prompt = 'Href:' }, function(href)
         if href == nil then
             return
         end
-        surrounder(pos_start, pos_end, '[', '](' .. href .. ')')
+        make_surrounder_function('[', '](' .. href .. ')')()
     end)
 end
 

--- a/lua/markdowny.lua
+++ b/lua/markdowny.lua
@@ -41,14 +41,15 @@ local function surrounder(pos_start, pos_end, before, after)
         if is_removing then
             local sub = string.sub(the_selection, 1 + #before, -1 - #after)
             start_line = pre_selection .. sub .. post_selection
+            -- Removed #after and #before because both surrounds are on the same line.
+            update_end_selection_mark(pos_end[1], pos_end[2] - #after - #before)
         else
             start_line = pre_selection .. before .. the_selection .. after .. post_selection
+            -- Added #after and #before because both surrounds are on the same line.
+            update_end_selection_mark(pos_end[1], pos_end[2] + #after + #before)
         end
 
         vim.api.nvim_buf_set_lines(0, pos_start[1] - 1, pos_start[1], true, { start_line })
-
-        -- Added #after and #before because both surrounds are on the same line.
-        update_end_selection_mark(pos_end[1], pos_end[2] + #after + #before)
     else
         local end_line = vim.api.nvim_buf_get_lines(0, pos_end[1] - 1, pos_end[1], true)[1]
 
@@ -72,17 +73,20 @@ local function surrounder(pos_start, pos_end, before, after)
             -- remove **
             start_line = pre_start_line .. post_start_line:sub(1 + #before)
             end_line = pre_end_line:sub(1, -1 - #after) .. post_end_line
+
+            -- Removed only #after because surrounds are on different lines.
+            update_end_selection_mark(pos_end[1], pos_end[2] - #after)
         else
             -- add **
             start_line = pre_start_line .. before .. post_start_line
             end_line = pre_end_line .. after .. post_end_line
+
+            -- Added only #after because surrounds are on different lines.
+            update_end_selection_mark(pos_end[1], pos_end[2] + #after)
         end
 
         vim.api.nvim_buf_set_lines(0, pos_start[1] - 1, pos_start[1], true, { start_line })
         vim.api.nvim_buf_set_lines(0, pos_end[1] - 1, pos_end[1], true, { end_line })
-
-        -- Added only #after because surrounds are on different lines.
-        update_end_selection_mark(pos_end[1], pos_end[2] + #after)
     end
 end
 local function make_surrounder_function(before, after)


### PR DESCRIPTION
I submitted a pull request #3, which included the commit 2b73508c9becd962da9c2c7ca38b3ac32ebd27e1, to address the reselection of text using the 'gv' command. In my previous implementation, I only considered the case of adding surrounding text, which resulted in an additional value being added to the '>' mark when removing the surrounding text. This patch addresses and resolves that issue.

#### Bug

https://user-images.githubusercontent.com/24286590/214547311-72150956-952e-4722-ba04-b32b03b7a017.mp4

#### Fix

https://user-images.githubusercontent.com/24286590/214547506-153da1e2-64a5-4163-b17c-59b4f0a638be.mp4
