### PR TITLE
Refactor & Support code block with `<C-e>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ All in visual mode
 - `<C-k>` add link to visually selected text
 - `<C-b>` toggle visually selected text bold
 - `<C-i>` toggle visually selected text italic
-- `<C-e>` add a code toggle to visually selected text
-
+- `<C-c>` add a code toggle to visually selected text
 
 ## Custom setup
 
@@ -52,7 +51,7 @@ Alternatively to default keymaps you can use custom keymaps. Make sure to keymap
 vim.keymap.set('v', '<C-b>', ":lua require('markdowny').bold()<cr>", { buffer = 0 })
 vim.keymap.set('v', '<C-i>', ":lua require('markdowny').italic()<cr>", { buffer = 0 })
 vim.keymap.set('v', '<C-k>', ":lua require('markdowny').link()<cr>", { buffer = 0 })
-vim.keymap.set('v', '<C-c>', ":lua require('markdowny').inline_code()<cr>", { buffer = 0 })
+vim.keymap.set('v', '<C-c>', ":lua require('markdowny').code()<cr>", { buffer = 0 })
 ```
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All in visual mode
 - `<C-k>` add link to visually selected text
 - `<C-b>` toggle visually selected text bold
 - `<C-i>` toggle visually selected text italic
+- `<C-e>` add a code toggle to visually selected text
 
 ## Custom setup
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ All in visual mode
 - `<C-k>` add link to visually selected text
 - `<C-b>` toggle visually selected text bold
 - `<C-i>` toggle visually selected text italic
-- `<C-c>` add a code toggle to visually selected text
+- `<C-e>` add a code toggle to visually selected text
 
 ## Custom setup
 
@@ -51,7 +51,7 @@ Alternatively to default keymaps you can use custom keymaps. Make sure to keymap
 vim.keymap.set('v', '<C-b>', ":lua require('markdowny').bold()<cr>", { buffer = 0 })
 vim.keymap.set('v', '<C-i>', ":lua require('markdowny').italic()<cr>", { buffer = 0 })
 vim.keymap.set('v', '<C-k>', ":lua require('markdowny').link()<cr>", { buffer = 0 })
-vim.keymap.set('v', '<C-c>', ":lua require('markdowny').code()<cr>", { buffer = 0 })
+vim.keymap.set('v', '<C-e>', ":lua require('markdowny').code()<cr>", { buffer = 0 })
 ```
 
 ## Acknowledgments

--- a/lua/markdowny.lua
+++ b/lua/markdowny.lua
@@ -270,7 +270,7 @@ function M.setup(opts)
         callback = function()
             vim.keymap.set('v', '<C-b>', ":lua require('markdowny').bold()<cr>", { buffer = 0 })
             vim.keymap.set('v', '<C-i>', ":lua require('markdowny').italic()<cr>", { buffer = 0 })
-            vim.keymap.set('v', '<C-c>', ":lua require('markdowny').code()<cr>", { buffer = 0 })
+            vim.keymap.set('v', '<C-e>', ":lua require('markdowny').code()<cr>", { buffer = 0 })
             vim.keymap.set('v', '<C-k>', ":lua require('markdowny').link()<cr>", { buffer = 0 })
         end,
     })

--- a/lua/markdowny.lua
+++ b/lua/markdowny.lua
@@ -1,227 +1,265 @@
 local M = {}
 
----@private
---- Counts if the Cyrillic character at the given index of
---- the string is double width.
----
----@param str (string) The input string
----@param idx (number) The index of the character to check
----
----@return (boolean) `true` if the character is double width, `false` otherwise
-local function __is_double_char(str, idx)
-    local char = str:sub(idx, idx + 1)
-    local display_width = vim.fn.strdisplaywidth(char)
+--[====================================================================================================================[
+                                            Buffer contents helper functions
+--]====================================================================================================================]
 
-    return #char ~= display_width
+-- Gets a line from the buffer, 1-indexed.
+---@param line_num integer The number of the line to be retrieved.
+---@return string @The contents of the line that was retrieved.
+---@nodiscard
+local get_line = function(line_num)
+    return vim.api.nvim_buf_get_lines(0, line_num - 1, line_num, false)[1]
 end
 
----@private
---- Update the '>' mark, which represents the end column
---- position of the selection, in visual mode after adding or
---- removing a surround, enabling the region to be reselected
---- using the 'gv' command.
----
----@param line (number) The line number of the mark to update.
----@param col  (number) The column/row number of the mark to update.
-local function __update_end_selection_mark(line, col)
-    vim.api.nvim_buf_set_mark(0, '>', line, col, {})
+-- Delete a line from the buffer, 1-indexed.
+---@param line_num integer The number of the line to be deleted.
+---@nodiscard
+local delete_line = function(line_num)
+    vim.api.nvim_buf_set_lines(0, line_num - 1, line_num, true, {})
 end
 
----@private
---- Update the '<' mark, which represents the start column
---- position of the selection, in visual mode after adding or
---- removing a surround, enabling the region to be reselected
---- using the 'gv' command.
----
----@param line (number) The line number of the mark to update.
----@param col  (number) The column/row number of the mark to update.
-local function __update_start_selection_mark(line, col)
-    vim.api.nvim_buf_set_mark(0, '<', line, col, {})
+-- Gets a selection of text from the buffer.
+---@param selection selection The selection of text to be retrieved.
+---@return text @The text from the buffer.
+---@nodiscard
+local get_text = function(selection)
+    local first_pos, last_pos = selection.first_pos, selection.last_pos
+    last_pos[2] = math.min(last_pos[2], #get_line(last_pos[1]))
+    return vim.api.nvim_buf_get_text(0, first_pos[1] - 1, first_pos[2] - 1, last_pos[1] - 1, last_pos[2], {})
 end
 
----@private
---- Gets a single line from the current buffer.
----
----@param line (number) The line number of current buffer.
-local function __buf_get_line(line)
-    return vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]
+-- Adds some text into the buffer at a given position.
+---@param pos position The position to be inserted at.
+---@param text text The text to be added.
+local insert_text = function(pos, text)
+    pos[2] = math.min(pos[2], #get_line(pos[1]) + 1)
+    vim.api.nvim_buf_set_text(0, pos[1] - 1, pos[2] - 1, pos[1] - 1, pos[2] - 1, text)
 end
 
----@private
---- Replace a lines to the current buffer.
----
----@param line (number) line index from current buffer.
----@param replacement (table) Array of lines to use as replacement
-local function __buf_set_line(line, replacement)
-    vim.api.nvim_buf_set_lines(0, line - 1, line, true, replacement)
+-- Replaces a given selection with a set of lines.
+---@param selection? selection The given selection.
+---@param text text The given text to replace the selection.
+local change_text = function(selection, text)
+    if not selection then
+        return
+    end
+    local first_pos, last_pos = selection.first_pos, selection.last_pos
+    vim.api.nvim_buf_set_text(0, first_pos[1] - 1, first_pos[2] - 1, last_pos[1] - 1, last_pos[2], text)
 end
 
----@private
---- Applies a specified surround text `before` and `after` at
---- a specified position `start_pos` and `end_pos` within the
---- current buffer.
----
----@param start_pos (table) The start position of text:
----  - line: (number) Line index
----  - col: (number) Column/row index
----@param end_pos (table) The end position of text:
----  - line: (number) Line index
----  - col: (number) Column/row index
----@param before (string) The string to insert before the selected text.
----@param after (string) The string to insert after the selected text.
----@param opts (nil|table) Optional keyword arguments:
----  - newline: Add surrounds string "before" and "after" to newline
---              In multi-line selection
-local function __toggle_surround(start_pos, end_pos, before, after, opts)
-    local start_line_txt = __buf_get_line(start_pos.line)
-    local end_line_txt = __buf_get_line(end_pos.line)
+--[====================================================================================================================[
+                                                 Cursor helper functions
+--]====================================================================================================================]
 
-    local is_same_line = start_pos.line == end_pos.line
+-- Sets the position of the cursor, 1-indexed.
+---@param pos position? The given position.
+local set_curpos = function(pos)
+    if not pos then
+        return
+    end
+    vim.api.nvim_win_set_cursor(0, { pos[1], pos[2] - 1 })
+end
 
-    local first = start_line_txt:sub(start_pos.col + 1, start_pos.col + #before) == before
-    local last = end_line_txt:sub(end_pos.col + 2 - #after, end_pos.col + 1) == after
+--[====================================================================================================================[
+                                                 Mark helper functions
+--]====================================================================================================================]
+
+-- Gets the row and column for a mark, 1-indexed, if it exists, returns nil otherwise.
+---@param mark string The mark whose position will be returned.
+---@return position @The position of the mark.
+---@nodiscard
+local get_mark = function(mark)
+    local position = vim.api.nvim_buf_get_mark(0, mark)
+    return { position[1], position[2] + 1 }
+end
+
+-- Sets the position of a mark, 1-indexed.
+---@param mark string The mark whose position will be returned.
+---@param position position? The position that the mark should be set to.
+local set_mark = function(mark, position)
+    if position then
+        vim.api.nvim_buf_set_mark(0, mark, position[1], position[2] - 1, {})
+    end
+end
+
+--[====================================================================================================================[
+                                             Byte indexing helper functions
+--]====================================================================================================================]
+
+-- Gets the position of the first byte of a character, according to the UTF-8 standard.
+---@param pos position The position of any byte in the character.
+---@return position @The position of the first byte of the character.
+---@nodiscard
+local get_first_byte = function(pos)
+    local byte = string.byte(get_line(pos[1]):sub(pos[2], pos[2]))
+    if not byte then
+        return pos
+    end
+    -- See https://en.wikipedia.org/wiki/UTF-8#Encoding
+    while byte >= 0x80 and byte < 0xc0 do
+        pos[2] = pos[2] - 1
+        byte = string.byte(get_line(pos[1]):sub(pos[2], pos[2]))
+    end
+    return pos
+end
+
+-- Gets the position of the last byte of a character, according to the UTF-8 standard.
+---@param pos position? The position of the beginning of the character.
+---@return position? @The position of the last byte of the character.
+---@nodiscard
+local get_last_byte = function(pos)
+    if not pos then
+        return nil
+    end
+
+    local byte = string.byte(get_line(pos[1]):sub(pos[2], pos[2]))
+    if not byte then
+        return pos
+    end
+    -- See https://en.wikipedia.org/wiki/UTF-8#Encoding
+    if byte >= 0xf0 then
+        pos[2] = pos[2] + 3
+    elseif byte >= 0xe0 then
+        pos[2] = pos[2] + 2
+    elseif byte >= 0xc0 then
+        pos[2] = pos[2] + 1
+    end
+    return pos
+end
+
+--[====================================================================================================================[
+                                                 Surround helper functions
+--]====================================================================================================================]
+
+-- Applies a specified surround text `before` and `after` at
+-- a selected within the current buffer.
+---@param before string The string to insert before the selected text.
+---@param after string The string to insert after the selected text.
+local inline_surround = function(before, after)
+    local s = get_first_byte(get_mark('<'))
+    local e = get_last_byte(get_mark('>'))
+
+    if s == nil or e == nil then
+        return
+    end
+
+    -- Manually count chars of last selected line in V-LINE mode due
+    -- to '>' reaching max int value. Address if it's neovim bug.
+    if vim.fn.visualmode() == 'V' then
+        e[2] = #get_line(e[1])
+    end
+
+    local selection = { first_pos = s, last_pos = e }
+    local text = get_text(selection)
+
+    local first = text[1]:sub(1, 1) == before
+    local last = text[#text]:sub(-1, -1) == after
+
+    local is_removing = first and last
+    local is_sameline = s[1] == e[1]
+
+    if is_removing then
+        text[1] = text[1]:sub(#before + 1, -1)
+        text[#text] = text[#text]:sub(1, -#after - 1)
+
+        change_text(selection, text)
+
+        if is_sameline then
+            e[2] = e[2] - #before - #after
+        else
+            e[2] = e[2] - #after
+        end
+    else
+        insert_text(s, { before })
+        e[2] = e[2] + 1
+
+        if is_sameline then
+            e[2] = e[2] + #before
+        end
+
+        insert_text(e, { after })
+        e[2] = e[2] + #after - 1
+    end
+
+    set_mark('>', e)
+end
+
+-- Applies a specified surround text `before` and `after` at
+-- a selected within the current buffer.
+---@param before string The string to insert before the selected text.
+---@param after string The string to insert after the selected text.
+local newline_surround = function(before, after)
+    local s = get_first_byte(get_mark('<'))
+    local e = get_last_byte(get_mark('>'))
+
+    if s == nil or e == nil then
+        return
+    end
+
+    -- Manually count chars of last selected line in V-LINE mode due
+    -- to '>' reaching max int value. Address if it's neovim bug.
+    if vim.fn.visualmode() == 'V' then
+        e[2] = #get_line(e[1])
+    end
+
+    local selection = { first_pos = s, last_pos = e }
+    local text = get_text(selection)
+
+    local first = text[1] == before
+    local last = text[#text] == after
 
     local is_removing = first and last
 
-    local idx_end = end_pos.col + 1
-    if __is_double_char(start_line_txt, end_pos.col + 1) then
-        idx_end = idx_end + 1
-    end
+    if is_removing then
+        delete_line(s[1])
+        e[1] = e[1] - 1
 
-    if is_same_line then
-        local pre_selection = string.sub(start_line_txt, 1, start_pos.col)
-        local the_selection = string.sub(start_line_txt, start_pos.col + 1, idx_end)
-        local post_selection = string.sub(start_line_txt, idx_end + 1)
+        delete_line(e[1])
+        e[1] = e[1] - 1
 
-        if is_removing then
-            -- remove **
-            local sub = string.sub(the_selection, 1 + #before, -1 - #after)
-            start_line_txt = pre_selection .. sub .. post_selection
-
-            -- Removed #after and #before because both surrounds are on the same line.
-            __update_end_selection_mark(end_pos.line, end_pos.col - #after - #before)
-        else
-            -- add **
-            start_line_txt = pre_selection .. before .. the_selection .. after .. post_selection
-
-            -- Added #after and #before because both surrounds are on the same line.
-            __update_end_selection_mark(end_pos.line, end_pos.col + #after + #before)
-        end
-
-        __buf_set_line(start_pos.line, { start_line_txt })
+        set_mark('>', { e[1], #text[#text - 1] - 1 })
+        set_curpos({ e[1], 1 })
     else
-        local newline = false
-        if opts and opts.newline then
-            newline = opts.newline
-        end
+        insert_text(s, { before, '' })
+        s = { s[1], 1 }
+        set_mark('<', s)
 
-        local pre_end_line_txt = string.sub(end_line_txt, 1, idx_end)
-        local post_end_line_txt = string.sub(end_line_txt, idx_end + 1)
+        e = { e[1] + 1, e[2] + 1 }
+        insert_text(e, { '', after })
+        e = { e[1] + 1, #after }
+        set_mark('>', e)
 
-        local pre_start_line_txt = string.sub(start_line_txt, 1, start_pos.col)
-        local post_start_line_txt = string.sub(start_line_txt, start_pos.col + 1)
-
-        if is_removing then
-            -- remove **
-            if newline then
-                --- Removing lines
-                vim.cmd(start_pos.line .. 'd')
-                vim.cmd(end_pos.line - 1 .. 'd')
-
-                __update_end_selection_mark(end_pos.line - 2, #pre_end_line_txt)
-
-                --- Change cursor position
-                vim.api.nvim_win_set_cursor(0, { end_pos.line - 2, 1 })
-            else
-                start_line_txt = pre_start_line_txt .. post_start_line_txt:sub(1 + #before)
-                end_line_txt = pre_end_line_txt:sub(1, -1 - #after) .. post_end_line_txt
-
-                -- Removed only #after because surrounds are on different lines.
-                __update_end_selection_mark(end_pos.line, end_pos.col - #after)
-            end
-        else
-            -- add **
-            if newline then
-                vim.api.nvim_buf_set_lines(0, start_pos.line - 1, start_pos.line - 1, false, { before })
-                __update_start_selection_mark(start_pos.line, 1)
-                vim.api.nvim_buf_set_lines(0, end_pos.line + 1, end_pos.line + 1, false, { after })
-                __update_end_selection_mark(end_pos.line + 2, #after)
-            else
-                start_line_txt = pre_start_line_txt .. before .. post_start_line_txt
-                end_line_txt = pre_end_line_txt .. after .. post_end_line_txt
-
-                -- Added only #after because surrounds are on different lines.
-                __update_end_selection_mark(end_pos.line, end_pos.col + #after)
-            end
-        end
-
-        if not newline then
-            __buf_set_line(start_pos.line, { start_line_txt })
-            __buf_set_line(end_pos.line, { end_line_txt })
-        end
+        set_curpos({ e[1] - 1, 1 })
     end
 end
+--[====================================================================================================================[
+                                               Markdown surround functions
+--]====================================================================================================================]
 
---- Wrap the selected text with "before" and "after" strings.
----
----@param sur (table) Single line surrounds
----  - before: (string) The string to place before the selected text
----  - after: (string) The string to place after the selected text
----@param mln_sur (table?) Multi line surrounds
----  - before: (string) The string to place before the selected text
----  - after: (string) The string to place after the selected text
----@param opts (nil|table) Optional keyword arguments:
----  - newline: Add surrounds string "before" and "after" to newline
---              In multi-line selection
-local function __wrap_sel_text(sur, mln_sur, opts)
-    local _start = vim.api.nvim_buf_get_mark(0, '<') -- [line, col]
-    local _end = vim.api.nvim_buf_get_mark(0, '>') -- [line, col]
-
-    local start_pos = { line = _start[1], col = _start[2] }
-    local end_pos = { line = _end[1], col = _end[2] }
-
-    local before, after = sur[1], sur[2]
-
-    if vim.fn.visualmode() == 'V' then
-        -- Manually count chars of last selected line in V-LINE mode due
-        -- to '>' reaching max int value. Address if it's neovim bug.
-        local end_line = __buf_get_line(end_pos.line)
-        end_pos.col = #end_line - 1
-
-        if mln_sur then
-            before, after = mln_sur[1], mln_sur[2]
-        end
-    end
-
-    __toggle_surround(start_pos, end_pos, before, after, opts)
-end
-
---- Surrounds the selected text with '**'
 function M.bold()
-    __wrap_sel_text({ '**', '**' })
+    inline_surround('**', '**')
 end
 
---- Surrounds the selected text with '_'
 function M.italic()
-    __wrap_sel_text({ '_', '_' })
+    inline_surround('_', '_')
 end
 
-
---- Prompts the user for a link and surrounds the selected text
---- with that link.
-function M.link()
-    vim.ui.input({ prompt = 'Href:' }, function(href)
-        if href ~= nil then
-            __wrap_sel_text({ '[', '](' .. href .. ')' })
-        end
-    end)
-end
-
---- Surrounds the selected text with '`' and '```' for multi-line
---- selections (V-LINE).
 function M.code()
-    __wrap_sel_text({ '`', '`' }, { '```', '```' }, { newline = true })
+    if vim.fn.visualmode() == 'V' then
+        newline_surround('```', '```')
+    else
+        inline_surround('`', '`')
+    end
 end
+
+function M.inline_code()
+    vim.deprecate('inline_code()', 'code()', 'v1', 'markdowny.nvim')
+end
+
+--[====================================================================================================================[
+                                                   Setup Function
+--]====================================================================================================================]
 
 function M.setup(opts)
     opts = opts or {}
@@ -232,9 +270,8 @@ function M.setup(opts)
         callback = function()
             vim.keymap.set('v', '<C-b>', ":lua require('markdowny').bold()<cr>", { buffer = 0 })
             vim.keymap.set('v', '<C-i>', ":lua require('markdowny').italic()<cr>", { buffer = 0 })
-            vim.keymap.set('v', '<C-e>', ":lua require('markdowny').code()<cr>", { buffer = 0 })
+            vim.keymap.set('v', '<C-c>', ":lua require('markdowny').code()<cr>", { buffer = 0 })
             vim.keymap.set('v', '<C-k>', ":lua require('markdowny').link()<cr>", { buffer = 0 })
-            vim.keymap.set('v', '<C-c>', ":lua require('markdowny').inline_code()<cr>", { buffer = 0 })
         end,
     })
 end


### PR DESCRIPTION
This refactor involves several modifications to the codebase aimed at enhancing **code quality and readability**. Key changes include the addition of Lua documentation to functions, the renaming of internal variables and functions, and the modification of the way position variables are accessed. The `surrounder` function has also been **heavily refactored** and renamed to `__toggle_surround` to reduce the number of lines of code and improve readability.

The codebase also includes a **new feature** that supports formatting **code blocks** using the `<C-e>` key combination (fixes #4). The feature consists of an implementation of a code function for handling **single-line** and **multi-line** delimiters using a table-based approach, which allows for more flexible handling of parameters. Additionally, the `__update_start_selection_mark` utility function has been introduced to facilitate updating the starting position of the selection mark when using optional parameters such as adding surround to multiple lines of code.


Further details on these changes can be found in individual commits.

https://user-images.githubusercontent.com/24286590/215761705-97d2156e-877d-4413-8e38-05b3bc78d0a8.mp4

