### PR TITLE
Rewrite plugin & Support single and multiline code blocks with `<C-e>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,24 +34,36 @@ use {
 require('markdowny').setup({filetypes = {'markdown', 'txt'}})
 ```
 
-## Keymaps
+## Default keymaps
 
 All in visual mode
 
-- `<C-k>` add link to visually selected text
-- `<C-b>` toggle visually selected text bold
-- `<C-i>` toggle visually selected text italic
-- `<C-c>` toggle visually selected text inline code
+- `<C-k>`: Adds a link to visually selected text.
+- `<C-b>`: Toggles visually selected text to bold.
+- `<C-i>`: Toggles visually selected text to italic.
+- `<C-e>`: Toggles visually selected text to inline code, and **V-LINE** selected text to a multiline code block.
 
 ## Custom setup
 
-Alternatively to default keymaps you can use custom keymaps. Make sure to keymap to a string, not lua function. Defaults
+Alternatively to default keymaps you can use custom keymaps without calling `setup` function, make sure to map to a string rather than a Lua function. Here are the defaults:
 
 ```lua
 vim.keymap.set('v', '<C-b>', ":lua require('markdowny').bold()<cr>", { buffer = 0 })
 vim.keymap.set('v', '<C-i>', ":lua require('markdowny').italic()<cr>", { buffer = 0 })
 vim.keymap.set('v', '<C-k>', ":lua require('markdowny').link()<cr>", { buffer = 0 })
-vim.keymap.set('v', '<C-c>', ":lua require('markdowny').inline_code()<cr>", { buffer = 0 })
+vim.keymap.set('v', '<C-e>', ":lua require('markdowny').code()<cr>", { buffer = 0 })
+```
+
+To apply the keymaps to specific filetypes, use `autocmd`:
+
+```lua
+vim.api.nvim_create_autocmd('FileType', {
+    desc = 'markdowny.nvim keymaps',
+    pattern = { 'markdown' },
+    callback = function()
+        -- add custom keymaps here
+    end,
+})
 ```
 
 ## Acknowledgments

--- a/lua/markdowny.lua
+++ b/lua/markdowny.lua
@@ -266,7 +266,7 @@ function M.italic()
     inline_surround('_', '_')
 end
 
-function M.inline_code()
+function M.code()
     if vim.fn.visualmode() == 'V' then
         newline_surround('```', '```')
     else
@@ -283,6 +283,13 @@ function M.link()
     end)
 end
 
+function M.inline_code()
+    vim.notify(
+        "[markdowny.nvim] 'inline_code' has been deprecated. Please use 'code' function instead.",
+        vim.log.levels.WARN
+    )
+end
+
 --[====================================================================================================================[
                                                    Setup Function
 --]====================================================================================================================]
@@ -297,7 +304,7 @@ function M.setup(opts)
             vim.keymap.set('v', '<C-b>', ":lua require('markdowny').bold()<cr>", { buffer = 0 })
             vim.keymap.set('v', '<C-i>', ":lua require('markdowny').italic()<cr>", { buffer = 0 })
             vim.keymap.set('v', '<C-k>', ":lua require('markdowny').link()<cr>", { buffer = 0 })
-            vim.keymap.set('v', '<C-c>', ":lua require('markdowny').inline_code()<cr>", { buffer = 0 })
+            vim.keymap.set('v', '<C-e>', ":lua require('markdowny').code()<cr>", { buffer = 0 })
         end,
     })
 end

--- a/lua/markdowny.lua
+++ b/lua/markdowny.lua
@@ -132,11 +132,25 @@ end
                                                  Surround helper functions
 --]====================================================================================================================]
 
--- Applies a specified surround text `before` and `after` at
--- a selected within the current buffer.
+-- Parse optional argument.
+---@param opts table|nil optional keyword arguments table
+---@param key string key of argumnet
+---@param default any default value
+---@return any @The value of parameter.
+local parse_arg = function(opts, key, default)
+    if opts and opts[key] ~= nil then
+        return opts[key]
+    else
+        return default
+    end
+end
+
+-- Applies a specified surround text `before` and `after` at a selected within the current buffer.
 ---@param before string The string to insert before the selected text.
 ---@param after string The string to insert after the selected text.
-local inline_surround = function(before, after)
+---@param opts table|nil Optional keyword arguments:
+--- - remove: Remove surround if possible (default true).
+local inline_surround = function(before, after, opts)
     local s = get_first_byte(get_mark('<'))
     local e = get_last_byte(get_mark('>'))
 
@@ -150,13 +164,16 @@ local inline_surround = function(before, after)
         e[2] = #get_line(e[1])
     end
 
+    -- Parsing Options
+    local remove = parse_arg(opts, 'remove', true)
+
     local selection = { first_pos = s, last_pos = e }
     local text = get_text(selection)
 
     local first = text[1]:sub(1, #before) == before
     local last = text[#text]:sub(-#after) == after
 
-    local is_removing = first and last
+    local is_removing = first and last and remove
     local is_sameline = s[1] == e[1]
 
     if is_removing then
@@ -185,11 +202,12 @@ local inline_surround = function(before, after)
     set_mark('>', e)
 end
 
--- Applies a specified surround text `before` and `after` at
--- a selected within the current buffer.
+-- Applies a specified surround text `before` and `after` text to the selected newline within the current buffer.
 ---@param before string The string to insert before the selected text.
 ---@param after string The string to insert after the selected text.
-local newline_surround = function(before, after)
+---@param opts table|nil Optional keyword arguments:
+--- - remove: Remove surround if possible (default true).
+local newline_surround = function(before, after, opts)
     local s = get_first_byte(get_mark('<'))
     local e = get_last_byte(get_mark('>'))
 
@@ -203,13 +221,16 @@ local newline_surround = function(before, after)
         e[2] = #get_line(e[1])
     end
 
+    -- Parsing Options
+    local remove = parse_arg(opts, 'remove', true)
+
     local selection = { first_pos = s, last_pos = e }
     local text = get_text(selection)
 
     local first = text[1] == before
     local last = text[#text] == after
 
-    local is_removing = first and last
+    local is_removing = first and last and remove
 
     if is_removing then
         delete_line(s[1])
@@ -258,7 +279,7 @@ function M.link()
         if href == nil then
             return
         end
-        inline_surround('[', '](' .. href .. ')')
+        inline_surround('[', '](' .. href .. ')', { remove = false })
     end)
 end
 


### PR DESCRIPTION
I have fully rewritten the plugin and incorporated the requested newline and single-line surroundings in the code block described in #7, while also taking into consideration issue #1.

### Fixes

- `link()` function now adds surrounding only where the old behavior of the plugin was removing a link if it matched the added link.
- Fixed the position calculation of surrounding for multi-width characters (e.g., Japanese and Chinese characters) that were being broken apart by the plugin's old behavior.
- Fixes #4 

### Breaking Changes

- The `inline_code()` function is now deprecated and should not be used. Please use the `code()` function instead.

- The keybinding for toggling a code block has been changed to `<C-e>`. This is because many Vim users have remapped `<C-c>` to the `Esc` key. Moreover, `<C-e>` is the default keybinding for code blocks on platforms like Notion, Discord, and GitHub.
